### PR TITLE
Add in-memory decryption, inline add/edit of variables, and git safety guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -685,11 +685,74 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
       "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -701,6 +764,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -3035,6 +3434,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.46.2",
       "cpu": [
@@ -3044,6 +3469,260 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -3105,6 +3784,22 @@
         "@tailwindcss/oxide-win32-x64-msvc": "4.1.11"
       }
     },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.11.tgz",
+      "integrity": "sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.1.11",
       "cpu": [
@@ -3114,6 +3809,191 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.11.tgz",
+      "integrity": "sha512-EgnK8kRchgmgzG6jE10UQNaH9Mwi2n+yw1jWmof9Vyg2lpKNX2ioe7CJdf9M5f8V9uaQxInenZkOxnTVL3fhAw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.11.tgz",
+      "integrity": "sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.11.tgz",
+      "integrity": "sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.11.tgz",
+      "integrity": "sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.11.tgz",
+      "integrity": "sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz",
+      "integrity": "sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.11.tgz",
+      "integrity": "sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.11.tgz",
+      "integrity": "sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@emnapi/wasi-threads": "^1.0.2",
+        "@napi-rs/wasm-runtime": "^0.2.11",
+        "@tybys/wasm-util": "^0.9.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",
+      "integrity": "sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz",
+      "integrity": "sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -3179,6 +4059,191 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.7.1.tgz",
+      "integrity": "sha512-CdYAefeM35zKsc91qIyKzbaO7FhzTyWKsE8hj7tEJ1INYpoh1NeNNyL/NSEA3Nebi5ilugioJ5tRK8ZXG8y3gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.7.1.tgz",
+      "integrity": "sha512-dnvyJrTA1UJxJjQ8q1N/gWomjP8Twij1BUQu2fdcT3OPpqlrbOk5R1yT0oD/721xoKNjroB5BXCsmmlykllxNg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.7.1.tgz",
+      "integrity": "sha512-FtBW6LJPNRTws3qyUc294AqCWU91l/H0SsFKq6q4Q45MSS4x6wxLxou8zB53tLDGEPx3JSoPLcDaSfPlSbyujQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.7.1.tgz",
+      "integrity": "sha512-/HXY0t4FHkpFzjeYS5c16mlA6z0kzn5uKLWptTLTdFSnYpr8FCnOP4Sdkvm2TDQPF2ERxXtNCd+WR/jQugbGnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.7.1.tgz",
+      "integrity": "sha512-GeW5lVI2GhhnaYckiDzstG2j2Jwlud5d2XefRGwlOK+C/bVGLT1le8MNPYK8wgRlpeK8fG1WnJJYD6Ke7YQ8bg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.7.1.tgz",
+      "integrity": "sha512-DprxKQkPxIPYwUgg+cscpv2lcIUhn2nxEPlk0UeaiV9vATxCXyytxr1gLcj3xgjGyNPlM0MlJyYaPy1JmRg1cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.7.1.tgz",
+      "integrity": "sha512-KLlq3kOK7OUyDR757c0zQjPULpGZpLhNB0lZmZpHXvoOUcqZoCXJHh4dT/mryWZJp5ilrem5l8o9ngrDo0X1AA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.7.1.tgz",
+      "integrity": "sha512-dH7KUjKkSypCeWPiainHyXoES3obS+JIZVoSwSZfKq2gWgs48FY3oT0hQNYrWveE+VR4VoR3b/F3CPGbgFvksA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.7.1.tgz",
+      "integrity": "sha512-1oeibfyWQPVcijOrTg709qhbXArjX3x1MPjrmA5anlygwrbByxLBcLXvotcOeULFcnH2FYUMMLLant8kgvwE5A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.7.1.tgz",
+      "integrity": "sha512-D7Q9kDObutuirCNLxYQ7KAg2Xxg99AjcdYz/KuMw5HvyEPbkC9Q7JL0vOrQOrHEHxIQ2lYzFOZvKKoC2yyqXcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -5385,6 +6450,198 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -2,7 +2,7 @@ use aes_gcm::{
     aead::{Aead, KeyInit, Payload},
     Aes256Gcm, Nonce,
 };
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use rand::Rng;
 use rusqlite::{params, Connection, Result as SqliteResult};
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,6 +206,37 @@ async fn is_file_git_tracked(file_path: String) -> Result<bool, String> {
     }
 }
 
+// Check whether a file is covered by .gitignore. Returns true (= safe, no
+// warning) when the file is ignored, and also when there is nothing to warn
+// about: no git, not a repo, or the file doesn't exist.
+#[tauri::command]
+async fn is_file_git_ignored(file_path: String) -> Result<bool, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Ok(true);
+    }
+
+    let parent = path.parent().unwrap_or(Path::new("."));
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(parent)
+        .arg("check-ignore")
+        .arg("-q")
+        .arg(&file_path)
+        .output();
+
+    match output {
+        // check-ignore exits 0 = ignored, 1 = not ignored, 128 = not a repo
+        Ok(o) => match o.status.code() {
+            Some(1) => Ok(false),
+            _ => Ok(true),
+        },
+        Err(_) => Ok(true),
+    }
+}
+
 // Decrypt a single variable in memory via `dotenvx get` - never modifies the file
 #[tauri::command]
 async fn get_decrypted_value(file_path: String, key: String) -> Result<String, String> {
@@ -548,6 +579,7 @@ pub fn run() {
             encrypt_env_file,
             decrypt_env_file,
             is_file_git_tracked,
+            is_file_git_ignored,
             get_decrypted_value,
             get_decrypted_values,
             set_env_value,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,6 +180,32 @@ async fn decrypt_env_file(file_path: String) -> Result<String, String> {
     }
 }
 
+// Check whether a file is tracked by git (used to warn before writing plaintext to it)
+#[tauri::command]
+async fn is_file_git_tracked(file_path: String) -> Result<bool, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let parent = path.parent().unwrap_or(Path::new("."));
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(parent)
+        .arg("ls-files")
+        .arg("--error-unmatch")
+        .arg(&file_path)
+        .output();
+
+    match output {
+        Ok(o) => Ok(o.status.success()),
+        // git missing or not a repo - can't check, so don't warn
+        Err(_) => Ok(false),
+    }
+}
+
 // Decrypt a single variable in memory via `dotenvx get` - never modifies the file
 #[tauri::command]
 async fn get_decrypted_value(file_path: String, key: String) -> Result<String, String> {
@@ -480,6 +506,7 @@ pub fn run() {
             open_folder,
             encrypt_env_file,
             decrypt_env_file,
+            is_file_git_tracked,
             get_decrypted_value,
             get_decrypted_values,
             rotate_key,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -358,7 +358,12 @@ async fn encrypt_env_key(file_path: String, key: String) -> Result<String, Strin
 // before it is written when the file has a public key, so plaintext never
 // touches the disk for encrypted files
 #[tauri::command]
-async fn set_env_value(file_path: String, key: String, value: String) -> Result<String, String> {
+async fn set_env_value(
+    file_path: String,
+    key: String,
+    value: String,
+    plain: bool,
+) -> Result<String, String> {
     let path = Path::new(&file_path);
 
     if !path.exists() {
@@ -376,13 +381,17 @@ async fn set_env_value(file_path: String, key: String, value: String) -> Result<
         return Err("dotenvx is not installed. Please install dotenvx first: brew install dotenvx".to_string());
     }
 
-    // Run dotenvx set command
-    let output = Command::new(&dotenvx_path)
-        .arg("set")
+    // Run dotenvx set command; --plain writes the value without encrypting
+    let mut cmd = Command::new(&dotenvx_path);
+    cmd.arg("set")
         .arg(&key)
         .arg(&value)
         .arg("-f")
-        .arg(&file_path)
+        .arg(&file_path);
+    if plain {
+        cmd.arg("--plain");
+    }
+    let output = cmd
         .current_dir(path.parent().unwrap_or(Path::new(".")))
         .output()
         .map_err(|e| format!("Failed to execute dotenvx set: {}", e))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,6 @@ use std::process::Command;
 use std::path::{Path, PathBuf};
 use std::fs;
 use serde::{Deserialize, Serialize};
-use std::sync::Mutex;
 use tauri::Manager;
 
 mod backup;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -314,6 +314,46 @@ async fn get_decrypted_values(file_path: String) -> Result<String, String> {
     }
 }
 
+// Encrypt a single variable in place via `dotenvx encrypt -k` - other
+// variables in the file are left untouched
+#[tauri::command]
+async fn encrypt_env_key(file_path: String, key: String) -> Result<String, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Err(format!("File does not exist: {}", file_path));
+    }
+
+    let dotenvx_path = find_dotenvx();
+
+    // Check if dotenvx is installed
+    let dotenvx_check = Command::new(&dotenvx_path)
+        .arg("--version")
+        .output();
+
+    if dotenvx_check.is_err() {
+        return Err("dotenvx is not installed. Please install dotenvx first: brew install dotenvx".to_string());
+    }
+
+    // Run dotenvx encrypt for the single key
+    let output = Command::new(&dotenvx_path)
+        .arg("encrypt")
+        .arg("-f")
+        .arg(&file_path)
+        .arg("-k")
+        .arg(&key)
+        .current_dir(path.parent().unwrap_or(Path::new(".")))
+        .output()
+        .map_err(|e| format!("Failed to execute dotenvx encrypt: {}", e))?;
+
+    if output.status.success() {
+        Ok(format!("{} encrypted successfully", key))
+    } else {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        Err(format!("dotenvx encrypt failed: {}", error_msg))
+    }
+}
+
 // Set (add or update) a variable via `dotenvx set` - the value is encrypted
 // before it is written when the file has a public key, so plaintext never
 // touches the disk for encrypted files
@@ -582,6 +622,7 @@ pub fn run() {
             get_decrypted_value,
             get_decrypted_values,
             set_env_value,
+            encrypt_env_key,
             rotate_key,
             create_backup,
             get_backup,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,6 +284,47 @@ async fn get_decrypted_values(file_path: String) -> Result<String, String> {
     }
 }
 
+// Set (add or update) a variable via `dotenvx set` - the value is encrypted
+// before it is written when the file has a public key, so plaintext never
+// touches the disk for encrypted files
+#[tauri::command]
+async fn set_env_value(file_path: String, key: String, value: String) -> Result<String, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Err(format!("File does not exist: {}", file_path));
+    }
+
+    let dotenvx_path = find_dotenvx();
+
+    // Check if dotenvx is installed
+    let dotenvx_check = Command::new(&dotenvx_path)
+        .arg("--version")
+        .output();
+
+    if dotenvx_check.is_err() {
+        return Err("dotenvx is not installed. Please install dotenvx first: brew install dotenvx".to_string());
+    }
+
+    // Run dotenvx set command
+    let output = Command::new(&dotenvx_path)
+        .arg("set")
+        .arg(&key)
+        .arg(&value)
+        .arg("-f")
+        .arg(&file_path)
+        .current_dir(path.parent().unwrap_or(Path::new(".")))
+        .output()
+        .map_err(|e| format!("Failed to execute dotenvx set: {}", e))?;
+
+    if output.status.success() {
+        Ok(format!("{} set successfully", key))
+    } else {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        Err(format!("dotenvx set failed: {}", error_msg))
+    }
+}
+
 // Helper function to derive .env file path from key name
 fn get_env_file_from_key(key_name: &str, keys_dir: &Path) -> PathBuf {
     // DOTENV_PRIVATE_KEY -> .env
@@ -509,6 +550,7 @@ pub fn run() {
             is_file_git_tracked,
             get_decrypted_value,
             get_decrypted_values,
+            set_env_value,
             rotate_key,
             create_backup,
             get_backup,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,6 +180,84 @@ async fn decrypt_env_file(file_path: String) -> Result<String, String> {
     }
 }
 
+// Decrypt a single variable in memory via `dotenvx get` - never modifies the file
+#[tauri::command]
+async fn get_decrypted_value(file_path: String, key: String) -> Result<String, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Err(format!("File does not exist: {}", file_path));
+    }
+
+    let dotenvx_path = find_dotenvx();
+
+    // Check if dotenvx is installed
+    let dotenvx_check = Command::new(&dotenvx_path)
+        .arg("--version")
+        .output();
+
+    if dotenvx_check.is_err() {
+        return Err("dotenvx is not installed. Please install dotenvx first: brew install dotenvx".to_string());
+    }
+
+    // Run dotenvx get command - decrypts to stdout, file on disk is untouched
+    let output = Command::new(&dotenvx_path)
+        .arg("get")
+        .arg(&key)
+        .arg("-f")
+        .arg(&file_path)
+        .current_dir(path.parent().unwrap_or(Path::new(".")))
+        .output()
+        .map_err(|e| format!("Failed to execute dotenvx get: {}", e))?;
+
+    if output.status.success() {
+        let value = String::from_utf8_lossy(&output.stdout);
+        Ok(value.strip_suffix('\n').unwrap_or(&value).to_string())
+    } else {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        Err(format!("dotenvx get failed: {}", error_msg))
+    }
+}
+
+// Decrypt every variable in memory via `dotenvx get --format json` - never modifies the file
+#[tauri::command]
+async fn get_decrypted_values(file_path: String) -> Result<String, String> {
+    let path = Path::new(&file_path);
+
+    if !path.exists() {
+        return Err(format!("File does not exist: {}", file_path));
+    }
+
+    let dotenvx_path = find_dotenvx();
+
+    // Check if dotenvx is installed
+    let dotenvx_check = Command::new(&dotenvx_path)
+        .arg("--version")
+        .output();
+
+    if dotenvx_check.is_err() {
+        return Err("dotenvx is not installed. Please install dotenvx first: brew install dotenvx".to_string());
+    }
+
+    // Run dotenvx get command - decrypts all keys to stdout as JSON, file on disk is untouched
+    let output = Command::new(&dotenvx_path)
+        .arg("get")
+        .arg("-f")
+        .arg(&file_path)
+        .arg("--format")
+        .arg("json")
+        .current_dir(path.parent().unwrap_or(Path::new(".")))
+        .output()
+        .map_err(|e| format!("Failed to execute dotenvx get: {}", e))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        Err(format!("dotenvx get failed: {}", error_msg))
+    }
+}
+
 // Helper function to derive .env file path from key name
 fn get_env_file_from_key(key_name: &str, keys_dir: &Path) -> PathBuf {
     // DOTENV_PRIVATE_KEY -> .env
@@ -402,6 +480,8 @@ pub fn run() {
             open_folder,
             encrypt_env_file,
             decrypt_env_file,
+            get_decrypted_value,
+            get_decrypted_values,
             rotate_key,
             create_backup,
             get_backup,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,15 @@ function App() {
     await StorageManager.setSelectedProject(project?.id || null);
   };
 
+  // Keep the selected project in sync when the sidebar rescans - it holds
+  // its own copy, and a stale copy keeps showing deleted files/keys
+  const handleProjectsUpdate = (updated: Project[]) => {
+    setProjects(updated);
+    setSelectedProject(
+      (prev) => (prev && updated.find((p) => p.id === prev.id)) || prev,
+    );
+  };
+
   const handleProjectUpdate = async (updatedProject: Project) => {
     await StorageManager.saveProject(updatedProject);
     setSelectedProject((prev) => {
@@ -93,7 +102,7 @@ function App() {
             projects={projects}
             selectedProjectId={selectedProject?.id || null}
             onProjectSelect={handleProjectSelect}
-            onProjectsUpdate={setProjects}
+            onProjectsUpdate={handleProjectsUpdate}
           />
         </aside>
 

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -166,7 +166,9 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
 
   useFileWatcher({
     projectPath: project?.path || "",
-    selectedFilePath: selectedEnvFile?.path,
+    // Watch .env.keys too - it has no tab, so external edits (e.g. deleting
+    // a private key) would otherwise go unnoticed until a manual refresh
+    watchPaths: [selectedEnvFile?.path, keysFile?.path],
     onFilesChanged: (updatedEnvFiles) => {
       if (project) {
         onProjectUpdate({

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -571,27 +571,25 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
           onValueChange={setSelectedFileId}
           className="w-full flex flex-col"
         >
-          <div className="sticky top-4 z-10">
-            <Card className="border-b p-0 py-1 px-1">
-              <TabsList className="flex flex-1 flex-wrap gap-1 justify-start bg-transparent p-0 h-auto">
+          <div className="sticky top-0 z-10 bg-background py-2">
+              <TabsList className="flex flex-wrap gap-1.5 justify-start h-auto w-fit bg-transparent p-0">
                 {tabFiles.map((envFile) => (
                   <TabsTrigger
                     key={envFile.id}
                     value={envFile.id}
-                    className="flex items-center gap-1 whitespace-nowrap px-2 py-1 text-sm h-8 hover:bg-accent hover:text-accent-foreground transition-colors flex-shrink-0"
+                    className="flex items-center gap-1.5 whitespace-nowrap px-3 py-1 text-sm h-8 border-border bg-card hover:bg-accent hover:text-accent-foreground transition-colors flex-shrink-0 data-[state=active]:bg-blue-500/10 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 data-[state=active]:border-blue-500/40 data-[state=active]:shadow-none"
                   >
-                    <span>{envFile.name}</span>
-                    {envFile.environment && (
-                      <Badge variant="outline" className="text-xs">
-                        {envFile.environment}
-                      </Badge>
+                    {envFile.isEncrypted ? (
+                      <Lock className="h-3 w-3 opacity-60" />
+                    ) : (
+                      <FileText className="h-3 w-3 opacity-60" />
                     )}
+                    <span>{envFile.name}</span>
                   </TabsTrigger>
                 ))}
               </TabsList>
-            </Card>
           </div>
-          <div className="pt-4">
+          <div className="pt-2">
             {tabFiles.map((envFile) => {
               const regularVariables = envFile.variables.filter(
                 (v) => !isDotenvxMetadata(v.key),
@@ -600,12 +598,16 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                 isDotenvxMetadata(v.key),
               );
               return (
-              <TabsContent key={envFile.id} value={envFile.id} className="mt-4">
+              <TabsContent key={envFile.id} value={envFile.id} className="mt-2">
                 <Card>
                   <CardHeader>
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3 flex-wrap">
-                        <FileText className="h-5 w-5 text-muted-foreground" />
+                        {envFile.isEncrypted ? (
+                          <Lock className="h-5 w-5 text-muted-foreground" />
+                        ) : (
+                          <FileText className="h-5 w-5 text-muted-foreground" />
+                        )}
                         <CardTitle className="text-lg">
                           {envFile.name}
                         </CardTitle>
@@ -620,19 +622,15 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                         {/* Encryption Status Badge */}
                         <Badge
                           variant={
-                            envFile.isEncrypted ? "default" : "secondary"
+                            envFile.isEncrypted ? "default" : "outline"
                           }
-                          className="gap-1"
+                          className={
+                            envFile.isEncrypted
+                              ? ""
+                              : "border-amber-500/50 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                          }
                         >
-                          {envFile.isEncrypted ? (
-                            <>
-                              <Lock className="h-3 w-3" /> Encrypted
-                            </>
-                          ) : (
-                            <>
-                              <Unlock className="h-3 w-3" /> Unencrypted
-                            </>
-                          )}
+                          {envFile.isEncrypted ? "Encrypted" : "Unencrypted"}
                         </Badge>
 
                         {/* File Type Badge */}
@@ -794,12 +792,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                 </Button>
                               )}
                           </div>
-                          {regularVariables.length === 0 ? (
-                            <p className="text-sm text-muted-foreground italic">
-                              No variables found in this file.
-                            </p>
-                          ) : (
-                            <div className="space-y-2">
+                          <div className="space-y-2">
                               {regularVariables.map((variable, index) => {
                                 const variableId = `${envFile.id}-${variable.key}`;
                                 const isVisible =
@@ -920,8 +913,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                   </div>
                                 );
                               })}
-                            </div>
-                          )}
+                          </div>
                           {addingToFileId === envFile.id ? (
                             <VariableForm
                               onSave={(key, value) =>

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -120,6 +120,44 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     setTimeout(() => setCopiedKey(null), 2000);
   }, []);
 
+  const copyDecryptedValue = useCallback(
+    async (envFile: EnvFile, variable: EnvVariable) => {
+      const variableId = `${envFile.id}-${variable.key}`;
+      let plaintext = decryptedValues.get(variableId) ?? variable.value;
+
+      // Decrypt in memory if needed - the value is copied without being shown
+      if (variable.isEncrypted && !decryptedValues.has(variableId)) {
+        try {
+          plaintext = await invoke<string>("get_decrypted_value", {
+            filePath: envFile.path,
+            key: variable.key,
+          });
+        } catch (error) {
+          console.error("Failed to decrypt variable:", error);
+          alert(`Failed to decrypt ${variable.key}: ${error}`);
+          return;
+        }
+      }
+
+      await navigator.clipboard.writeText(plaintext);
+      setCopiedKey(`value-${variableId}`);
+      setTimeout(() => setCopiedKey(null), 2000);
+
+      // Clear the clipboard after 30s, but only if it still holds this secret
+      const copied = plaintext;
+      setTimeout(async () => {
+        try {
+          if ((await navigator.clipboard.readText()) === copied) {
+            await navigator.clipboard.writeText("");
+          }
+        } catch {
+          // clipboard not readable - leave it alone
+        }
+      }, 30_000);
+    },
+    [decryptedValues],
+  );
+
   const toggleVariableVisibility = useCallback(
     async (envFile: EnvFile, variable: EnvVariable) => {
       const variableId = `${envFile.id}-${variable.key}`;
@@ -558,6 +596,27 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                         }
                                         isVisible={isVisible}
                                       />
+                                      {variable.value && (
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          onClick={() =>
+                                            copyDecryptedValue(
+                                              envFile,
+                                              variable,
+                                            )
+                                          }
+                                          className="h-6 w-6 p-0"
+                                          title="Copy value (decrypted in memory, clipboard clears after 30s)"
+                                        >
+                                          {copiedKey ===
+                                          `value-${variableId}` ? (
+                                            <Check className="h-4 w-4 text-green-600" />
+                                          ) : (
+                                            <Copy className="h-4 w-4" />
+                                          )}
+                                        </Button>
+                                      )}
                                       {variable.value && (
                                         <Button
                                           variant="ghost"

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -117,6 +117,11 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   // Pencil click shells out to dotenvx to prefill the plaintext - show a
   // spinner on the clicked pencil while that runs
   const [editLoadingId, setEditLoadingId] = useState<string | null>(null);
+  // Same deal for the eye: first reveal of an encrypted value shells out too
+  const [revealLoadingId, setRevealLoadingId] = useState<string | null>(null);
+  // And for copy-to-clipboard on an encrypted value, and Show All
+  const [copyLoadingId, setCopyLoadingId] = useState<string | null>(null);
+  const [showAllLoading, setShowAllLoading] = useState(false);
   const [showBackupManager, setShowBackupManager] = useState(false);
   const [showKeysManager, setShowKeysManager] = useState(false);
   const [currentEnvFile, setCurrentEnvFile] = useState<EnvFile | null>(null);
@@ -186,21 +191,26 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     // Decrypt encrypted files in memory via `dotenvx get --format json`
     // so "Show All" reveals plaintext without touching the files on disk
     const newDecrypted = new Map<string, string>();
-    for (const file of project?.envFiles || []) {
-      if (file.type === "keys") continue;
-      if (!file.variables.some((v) => v.isEncrypted)) continue;
-      try {
-        const json = await invoke<string>("get_decrypted_values", {
-          filePath: file.path,
-        });
-        const values: Record<string, string> = JSON.parse(json);
-        for (const [key, value] of Object.entries(values)) {
-          if (isDotenvxMetadata(key)) continue;
-          newDecrypted.set(`${file.id}-${key}`, value);
+    setShowAllLoading(true);
+    try {
+      for (const file of project?.envFiles || []) {
+        if (file.type === "keys") continue;
+        if (!file.variables.some((v) => v.isEncrypted)) continue;
+        try {
+          const json = await invoke<string>("get_decrypted_values", {
+            filePath: file.path,
+          });
+          const values: Record<string, string> = JSON.parse(json);
+          for (const [key, value] of Object.entries(values)) {
+            if (isDotenvxMetadata(key)) continue;
+            newDecrypted.set(`${file.id}-${key}`, value);
+          }
+        } catch (error) {
+          console.error(`Failed to decrypt ${file.name} in memory:`, error);
         }
-      } catch (error) {
-        console.error(`Failed to decrypt ${file.name} in memory:`, error);
       }
+    } finally {
+      setShowAllLoading(false);
     }
 
     const allKeys = new Set<string>();
@@ -237,6 +247,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
 
       // Decrypt in memory if needed - the value is copied without being shown
       if (variable.isEncrypted && !decryptedValues.has(variableId)) {
+        setCopyLoadingId(variableId);
         try {
           plaintext = await invoke<string>("get_decrypted_value", {
             filePath: envFile.path,
@@ -246,6 +257,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
           console.error("Failed to decrypt variable:", error);
           alert(`Failed to decrypt ${variable.key}: ${error}`);
           return;
+        } finally {
+          setCopyLoadingId(null);
         }
       }
 
@@ -281,6 +294,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
       // Encrypted value: decrypt in memory so the eye shows plaintext,
       // without ever rewriting the file on disk
       if (variable.isEncrypted && !decryptedValues.has(variableId)) {
+        setRevealLoadingId(variableId);
         try {
           const plaintext = await invoke<string>("get_decrypted_value", {
             filePath: envFile.path,
@@ -291,6 +305,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
           console.error("Failed to decrypt variable:", error);
           alert(`Failed to decrypt ${variable.key}: ${error}`);
           return;
+        } finally {
+          setRevealLoadingId(null);
         }
       }
 
@@ -884,6 +900,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                   variant="outline"
                                   size="sm"
                                   onClick={toggleAllVisibility}
+                                  disabled={showAllLoading}
                                   className="h-8"
                                   title={
                                     showAllValues
@@ -891,7 +908,12 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                       : "Show all values (encrypted files are decrypted in memory, files untouched)"
                                   }
                                 >
-                                  {showAllValues ? (
+                                  {showAllLoading ? (
+                                    <>
+                                      <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                                      Show All
+                                    </>
+                                  ) : showAllValues ? (
                                     <>
                                       <EyeOff className="h-4 w-4 mr-1" />
                                       Hide All
@@ -983,11 +1005,14 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                               variable,
                                             )
                                           }
+                                          disabled={copyLoadingId !== null}
                                           className="h-6 w-6 p-0"
                                           title="Copy value (decrypted in memory, clipboard clears after 30s)"
                                         >
-                                          {copiedKey ===
-                                          `value-${variableId}` ? (
+                                          {copyLoadingId === variableId ? (
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                          ) : copiedKey ===
+                                            `value-${variableId}` ? (
                                             <Check className="h-4 w-4 text-green-600" />
                                           ) : (
                                             <Copy className="h-4 w-4" />
@@ -1006,10 +1031,13 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                               variable,
                                             )
                                           }
+                                          disabled={revealLoadingId !== null}
                                           className="h-6 w-6 p-0"
                                           title="Reveal (decrypts in memory, file untouched)"
                                         >
-                                          {isVisible ? (
+                                          {revealLoadingId === variableId ? (
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                          ) : isVisible ? (
                                             <EyeOff className="h-4 w-4" />
                                           ) : (
                                             <Eye className="h-4 w-4" />

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -351,6 +351,54 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     [saveVariable],
   );
 
+  const handleEncryptVariable = useCallback(
+    async (envFile: EnvFile, variable: EnvVariable) => {
+      if (!project) return;
+
+      // Encrypting the first value in a keyless file has side effects far
+      // bigger than the icon suggests - confirm the bootstrap once
+      const hasKeypair = envFile.variables.some((v) =>
+        isDotenvxMetadata(v.key),
+      );
+      if (!hasKeypair) {
+        const proceed = await confirm(
+          `${envFile.name} is not set up for encryption yet. Encrypting ` +
+            `${variable.key} will add DOTENV_PUBLIC_KEY to the file and ` +
+            `create .env.keys with the private decryption key.`,
+          {
+            title: "Set up encryption?",
+            kind: "info",
+            okLabel: "Encrypt",
+            cancelLabel: "Cancel",
+          },
+        );
+        if (!proceed) return;
+      }
+
+      try {
+        await invoke<string>("encrypt_env_key", {
+          filePath: envFile.path,
+          key: variable.key,
+        });
+
+        // Reload the file from disk to get updated variables
+        const { FileScanner } = await import("../utils/fileScanner");
+        const updatedEnvFiles = await FileScanner.scanProjectFolder(
+          project.path,
+        );
+        onProjectUpdate({
+          ...project,
+          envFiles: updatedEnvFiles,
+          lastModified: new Date().toISOString(),
+        });
+      } catch (error) {
+        console.error("Failed to encrypt variable:", error);
+        alert(`Failed to encrypt ${variable.key}: ${error}`);
+      }
+    },
+    [project, onProjectUpdate],
+  );
+
   const startEditVariable = useCallback(
     async (envFile: EnvFile, variable: EnvVariable) => {
       const variableId = `${envFile.id}-${variable.key}`;
@@ -940,6 +988,23 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                           ) : (
                                             <Eye className="h-4 w-4" />
                                           )}
+                                        </Button>
+                                      ) : variable.value &&
+                                        isPlaintext &&
+                                        envFile.type !== "example" ? (
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          onClick={() =>
+                                            handleEncryptVariable(
+                                              envFile,
+                                              variable,
+                                            )
+                                          }
+                                          className="h-6 w-6 p-0"
+                                          title="Encrypt this value"
+                                        >
+                                          <Lock className="h-4 w-4" />
                                         </Button>
                                       ) : (
                                         <span className="h-6 w-6" />

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -297,16 +297,23 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   );
 
   const saveVariable = useCallback(
-    async (envFile: EnvFile, key: string, value: string): Promise<boolean> => {
+    async (
+      envFile: EnvFile,
+      key: string,
+      value: string,
+      plain: boolean,
+    ): Promise<boolean> => {
       if (!project) return false;
 
       try {
         // dotenvx set encrypts the value in-flight when the file has a
-        // public key, so plaintext never lands on disk for encrypted files
+        // public key, so plaintext never lands on disk for encrypted files;
+        // --plain preserves deliberately unencrypted variables
         await invoke<string>("set_env_value", {
           filePath: envFile.path,
           key,
           value,
+          plain,
         });
 
         // Reload the file from disk to get updated variables
@@ -331,7 +338,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
 
   const handleAddVariable = useCallback(
     async (envFile: EnvFile, key: string, value: string) => {
-      if (envFile.variables.some((v) => v.key === key)) {
+      const existing = envFile.variables.find((v) => v.key === key);
+      if (existing) {
         const proceed = await confirm(
           `${key} already exists in ${envFile.name}. Overwrite its value?`,
           {
@@ -344,7 +352,13 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
         if (!proceed) return;
       }
 
-      if (await saveVariable(envFile, key, value)) {
+      // Example files stay plaintext; overwriting keeps the variable's
+      // current encryption state; brand-new variables encrypt by default
+      const plain =
+        envFile.type === "example" ||
+        (existing ? !existing.isEncrypted : false);
+
+      if (await saveVariable(envFile, key, value, plain)) {
         setAddingToFileId(null);
       }
     },
@@ -426,7 +440,10 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   const handleEditVariable = useCallback(
     async (envFile: EnvFile, variable: EnvVariable, value: string) => {
       const variableId = `${envFile.id}-${variable.key}`;
-      if (await saveVariable(envFile, variable.key, value)) {
+      // Editing preserves the variable's encryption state - a plaintext
+      // variable only becomes encrypted via the explicit lock action
+      const plain = envFile.type === "example" || !variable.isEncrypted;
+      if (await saveVariable(envFile, variable.key, value, plain)) {
         // Keep the in-memory plaintext cache in sync if this value was revealed
         setDecryptedValues((prev) =>
           prev.has(variableId) ? new Map(prev).set(variableId, value) : prev,

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -805,7 +805,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                               </Button>
                             )}
                             {regularVariables.length > 0 &&
-                              regularVariables.some((v) => v.value) && (
+                              regularVariables.some((v) => v.isEncrypted) && (
                                 <Button
                                   variant="outline"
                                   size="sm"
@@ -835,8 +835,12 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                           <div className="space-y-2">
                               {displayVariables.map((variable, index) => {
                                 const variableId = `${envFile.id}-${variable.key}`;
+                                // Plaintext values are already readable on disk -
+                                // masking them here adds friction, not security
+                                const isPlaintext = !variable.isEncrypted;
                                 const isVisible =
-                                  visibleVariables.has(variableId);
+                                  visibleVariables.has(variableId) ||
+                                  isPlaintext;
                                 if (editingVariableId === variableId) {
                                   return (
                                     <VariableForm
@@ -914,7 +918,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                           )}
                                         </Button>
                                       )}
-                                      {variable.value && (
+                                      {variable.value && !isPlaintext && (
                                         <Button
                                           variant="ghost"
                                           size="sm"

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { EnvFile, Project } from "../types";
+import { EnvFile, EnvVariable, Project } from "../types";
 import { invoke } from "@tauri-apps/api/core";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
@@ -45,6 +45,10 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   const [visibleVariables, setVisibleVariables] = useState<Set<string>>(
     new Set(),
   );
+  // Plaintext values decrypted in memory via `dotenvx get` - never written to disk
+  const [decryptedValues, setDecryptedValues] = useState<Map<string, string>>(
+    new Map(),
+  );
   const [showAllValues, setShowAllValues] = useState(false);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [showBackupManager, setShowBackupManager] = useState(false);
@@ -73,19 +77,41 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     pollInterval: 5000,
   });
 
-  const toggleAllVisibility = useCallback(() => {
+  const toggleAllVisibility = useCallback(async () => {
     if (showAllValues) {
       setVisibleVariables(new Set());
-    } else {
-      const allKeys = new Set<string>();
-      project?.envFiles.forEach((file) => {
-        file.variables.forEach((variable) => {
-          allKeys.add(`${file.id}-${variable.key}`);
-        });
-      });
-      setVisibleVariables(allKeys);
+      setDecryptedValues(new Map());
+      setShowAllValues(false);
+      return;
     }
-    setShowAllValues(!showAllValues);
+
+    // Decrypt encrypted files in memory via `dotenvx get --format json`
+    // so "Show All" reveals plaintext without touching the files on disk
+    const newDecrypted = new Map<string, string>();
+    for (const file of project?.envFiles || []) {
+      if (!file.variables.some((v) => v.isEncrypted)) continue;
+      try {
+        const json = await invoke<string>("get_decrypted_values", {
+          filePath: file.path,
+        });
+        const values: Record<string, string> = JSON.parse(json);
+        for (const [key, value] of Object.entries(values)) {
+          newDecrypted.set(`${file.id}-${key}`, value);
+        }
+      } catch (error) {
+        console.error(`Failed to decrypt ${file.name} in memory:`, error);
+      }
+    }
+
+    const allKeys = new Set<string>();
+    project?.envFiles.forEach((file) => {
+      file.variables.forEach((variable) => {
+        allKeys.add(`${file.id}-${variable.key}`);
+      });
+    });
+    setDecryptedValues(newDecrypted);
+    setVisibleVariables(allKeys);
+    setShowAllValues(true);
   }, [showAllValues, project]);
 
   const copyToClipboard = useCallback((text: string, key: string) => {
@@ -94,17 +120,44 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     setTimeout(() => setCopiedKey(null), 2000);
   }, []);
 
-  const toggleVariableVisibility = useCallback((variableKey: string) => {
-    setVisibleVariables((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(variableKey)) {
-        newSet.delete(variableKey);
-      } else {
-        newSet.add(variableKey);
+  const toggleVariableVisibility = useCallback(
+    async (envFile: EnvFile, variable: EnvVariable) => {
+      const variableId = `${envFile.id}-${variable.key}`;
+
+      if (visibleVariables.has(variableId)) {
+        setVisibleVariables((prev) => {
+          const newSet = new Set(prev);
+          newSet.delete(variableId);
+          return newSet;
+        });
+        setDecryptedValues((prev) => {
+          const newMap = new Map(prev);
+          newMap.delete(variableId);
+          return newMap;
+        });
+        return;
       }
-      return newSet;
-    });
-  }, []);
+
+      // Encrypted value: decrypt in memory so the eye shows plaintext,
+      // without ever rewriting the file on disk
+      if (variable.isEncrypted && !decryptedValues.has(variableId)) {
+        try {
+          const plaintext = await invoke<string>("get_decrypted_value", {
+            filePath: envFile.path,
+            key: variable.key,
+          });
+          setDecryptedValues((prev) => new Map(prev).set(variableId, plaintext));
+        } catch (error) {
+          console.error("Failed to decrypt variable:", error);
+          alert(`Failed to decrypt ${variable.key}: ${error}`);
+          return;
+        }
+      }
+
+      setVisibleVariables((prev) => new Set(prev).add(variableId));
+    },
+    [visibleVariables, decryptedValues],
+  );
 
   const handleOpenFolder = useCallback(async () => {
     if (!project) return;
@@ -439,6 +492,11 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                   size="sm"
                                   onClick={toggleAllVisibility}
                                   className="h-8"
+                                  title={
+                                    showAllValues
+                                      ? "Hide all values"
+                                      : "Show all values (encrypted files are decrypted in memory, files untouched)"
+                                  }
                                 >
                                   {showAllValues ? (
                                     <>
@@ -494,7 +552,10 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                     </div>
                                     <div className="flex items-center gap-2">
                                       <VariableValueDisplay
-                                        value={variable.value}
+                                        value={
+                                          decryptedValues.get(variableId) ??
+                                          variable.value
+                                        }
                                         isVisible={isVisible}
                                       />
                                       {variable.value && (
@@ -502,9 +563,17 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                           variant="ghost"
                                           size="sm"
                                           onClick={() =>
-                                            toggleVariableVisibility(variableId)
+                                            toggleVariableVisibility(
+                                              envFile,
+                                              variable,
+                                            )
                                           }
                                           className="h-6 w-6 p-0"
+                                          title={
+                                            variable.isEncrypted
+                                              ? "Reveal (decrypts in memory, file untouched)"
+                                              : "Reveal"
+                                          }
                                         >
                                           {isVisible ? (
                                             <EyeOff className="h-4 w-4" />

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -897,7 +897,9 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                         }
                                         isVisible={isVisible}
                                       />
-                                      {variable.value && (
+                                      {/* Fixed button slots keep the value column
+                                          aligned across rows with different actions */}
+                                      {variable.value ? (
                                         <Button
                                           variant="ghost"
                                           size="sm"
@@ -917,8 +919,10 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                             <Copy className="h-4 w-4" />
                                           )}
                                         </Button>
+                                      ) : (
+                                        <span className="h-6 w-6" />
                                       )}
-                                      {variable.value && !isPlaintext && (
+                                      {variable.value && !isPlaintext ? (
                                         <Button
                                           variant="ghost"
                                           size="sm"
@@ -929,11 +933,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                             )
                                           }
                                           className="h-6 w-6 p-0"
-                                          title={
-                                            variable.isEncrypted
-                                              ? "Reveal (decrypts in memory, file untouched)"
-                                              : "Reveal"
-                                          }
+                                          title="Reveal (decrypts in memory, file untouched)"
                                         >
                                           {isVisible ? (
                                             <EyeOff className="h-4 w-4" />
@@ -941,6 +941,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                             <Eye className="h-4 w-4" />
                                           )}
                                         </Button>
+                                      ) : (
+                                        <span className="h-6 w-6" />
                                       )}
                                       <Button
                                         variant="ghost"

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { EnvFile, EnvVariable, Project } from "../types";
 import { invoke } from "@tauri-apps/api/core";
+import { confirm } from "@tauri-apps/plugin-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
@@ -252,6 +253,32 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
       if (!envFile.isEncrypted) {
         alert("This file is not encrypted");
         return;
+      }
+
+      // Decrypting rewrites the file with plaintext - warn if git could commit it
+      try {
+        const tracked = await invoke<boolean>("is_file_git_tracked", {
+          filePath: envFile.path,
+        });
+        if (tracked) {
+          // window.confirm is patched by the dialog plugin to return a
+          // Promise, which is always truthy - await the plugin API instead
+          const proceed = await confirm(
+            `${envFile.name} is tracked by git.\n\n` +
+              "Decrypting will write plaintext secrets to a file that could " +
+              "be accidentally committed. To view values without modifying " +
+              "the file, use the eye icon or Show All instead.",
+            {
+              title: "Decrypt file on disk?",
+              kind: "warning",
+              okLabel: "Decrypt Anyway",
+              cancelLabel: "Cancel",
+            },
+          );
+          if (!proceed) return;
+        }
+      } catch (error) {
+        console.error("Failed to check git status:", error);
       }
 
       setIsProcessing(envFile.id);

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { EnvFile, EnvVariable, Project } from "../types";
 import { invoke } from "@tauri-apps/api/core";
 import { confirm } from "@tauri-apps/plugin-dialog";
@@ -50,6 +50,51 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   const [decryptedValues, setDecryptedValues] = useState<Map<string, string>>(
     new Map(),
   );
+  // Revealed values re-mask automatically so secrets don't linger on screen
+  const REMASK_DELAY_MS = 60_000;
+  const remaskTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  const hideVariable = useCallback((variableId: string) => {
+    setVisibleVariables((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(variableId);
+      return newSet;
+    });
+    setDecryptedValues((prev) => {
+      const newMap = new Map(prev);
+      newMap.delete(variableId);
+      return newMap;
+    });
+  }, []);
+
+  const cancelRemask = useCallback((variableId: string) => {
+    const timer = remaskTimers.current.get(variableId);
+    if (timer) {
+      clearTimeout(timer);
+      remaskTimers.current.delete(variableId);
+    }
+  }, []);
+
+  const scheduleRemask = useCallback(
+    (variableId: string) => {
+      cancelRemask(variableId);
+      remaskTimers.current.set(
+        variableId,
+        setTimeout(() => {
+          remaskTimers.current.delete(variableId);
+          hideVariable(variableId);
+        }, REMASK_DELAY_MS),
+      );
+    },
+    [cancelRemask, hideVariable],
+  );
+
+  useEffect(() => {
+    const timers = remaskTimers.current;
+    return () => timers.forEach(clearTimeout);
+  }, []);
   const [showAllValues, setShowAllValues] = useState(false);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [showBackupManager, setShowBackupManager] = useState(false);
@@ -80,6 +125,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
 
   const toggleAllVisibility = useCallback(async () => {
     if (showAllValues) {
+      remaskTimers.current.forEach(clearTimeout);
+      remaskTimers.current.clear();
       setVisibleVariables(new Set());
       setDecryptedValues(new Map());
       setShowAllValues(false);
@@ -113,7 +160,15 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     setDecryptedValues(newDecrypted);
     setVisibleVariables(allKeys);
     setShowAllValues(true);
-  }, [showAllValues, project]);
+    allKeys.forEach(scheduleRemask);
+  }, [showAllValues, project, scheduleRemask]);
+
+  // When every revealed value has re-masked, flip the button back to Show All
+  useEffect(() => {
+    if (showAllValues && visibleVariables.size === 0) {
+      setShowAllValues(false);
+    }
+  }, [showAllValues, visibleVariables]);
 
   const copyToClipboard = useCallback((text: string, key: string) => {
     navigator.clipboard.writeText(text);
@@ -164,16 +219,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
       const variableId = `${envFile.id}-${variable.key}`;
 
       if (visibleVariables.has(variableId)) {
-        setVisibleVariables((prev) => {
-          const newSet = new Set(prev);
-          newSet.delete(variableId);
-          return newSet;
-        });
-        setDecryptedValues((prev) => {
-          const newMap = new Map(prev);
-          newMap.delete(variableId);
-          return newMap;
-        });
+        cancelRemask(variableId);
+        hideVariable(variableId);
         return;
       }
 
@@ -194,8 +241,9 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
       }
 
       setVisibleVariables((prev) => new Set(prev).add(variableId));
+      scheduleRemask(variableId);
     },
-    [visibleVariables, decryptedValues],
+    [visibleVariables, decryptedValues, cancelRemask, hideVariable, scheduleRemask],
   );
 
   const handleOpenFolder = useCallback(async () => {

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -358,7 +358,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   );
 
   const handleAddVariable = useCallback(
-    async (envFile: EnvFile, key: string, value: string) => {
+    async (envFile: EnvFile, key: string, value: string, encrypt: boolean) => {
       const existing = envFile.variables.find((v) => v.key === key);
       if (existing) {
         const proceed = await confirm(
@@ -373,11 +373,29 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
         if (!proceed) return;
       }
 
-      // Example files stay plaintext; overwriting keeps the variable's
-      // current encryption state; brand-new variables encrypt by default
-      const plain =
-        envFile.type === "example" ||
-        (existing ? !existing.isEncrypted : false);
+      // Example files stay plaintext; otherwise the form's lock toggle
+      // decides, defaulting to the file's current setup
+      const plain = envFile.type === "example" || !encrypt;
+
+      // Encrypting into a keyless file bootstraps a keypair - same side
+      // effect the lock icon confirms, so confirm it here too
+      const hasKeypair = envFile.variables.some((v) =>
+        isDotenvxMetadata(v.key),
+      );
+      if (!plain && !hasKeypair) {
+        const proceed = await confirm(
+          `${envFile.name} is not set up for encryption yet. Encrypting ` +
+            `${key} will add DOTENV_PUBLIC_KEY to the file and create ` +
+            `.env.keys with the private decryption key.`,
+          {
+            title: "Set up encryption?",
+            kind: "info",
+            okLabel: "Encrypt",
+            cancelLabel: "Cancel",
+          },
+        );
+        if (!proceed) return;
+      }
 
       if (await saveVariable(envFile, key, value, plain)) {
         setAddingToFileId(null);
@@ -1087,8 +1105,24 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                           </div>
                           {addingToFileId === envFile.id ? (
                             <VariableForm
-                              onSave={(key, value) =>
-                                handleAddVariable(envFile, key, value)
+                              encryptToggle={
+                                envFile.type === "example"
+                                  ? undefined
+                                  : {
+                                      // Keyed files encrypt new values by
+                                      // default; keyless files stay plaintext
+                                      initial: envFile.variables.some((v) =>
+                                        isDotenvxMetadata(v.key),
+                                      ),
+                                    }
+                              }
+                              onSave={(key, value, encrypt) =>
+                                handleAddVariable(
+                                  envFile,
+                                  key,
+                                  value,
+                                  encrypt ?? false,
+                                )
                               }
                               onCancel={() => setAddingToFileId(null)}
                             />

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -110,10 +110,40 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   );
   const [editInitialValue, setEditInitialValue] = useState("");
   const [showBackupManager, setShowBackupManager] = useState(false);
+  const [showKeysManager, setShowKeysManager] = useState(false);
   const [currentEnvFile, setCurrentEnvFile] = useState<EnvFile | null>(null);
+
+  // .env.keys holds private decryption keys - it gets its own dialog off the
+  // project header instead of masquerading as an environment file tab
+  const tabFiles = project?.envFiles.filter((f) => f.type !== "keys") ?? [];
+  const keysFile = project?.envFiles.find((f) => f.type === "keys");
+
   const [selectedFileId, setSelectedFileId] = useState<string | null>(
-    project?.envFiles[0]?.id || null,
+    project?.envFiles.find((f) => f.type !== "keys")?.id || null,
   );
+
+  // A git-tracked .env.keys means private keys could be committed - the
+  // single worst failure mode of the dotenvx model, so check and warn loudly
+  const [keysFileTracked, setKeysFileTracked] = useState(false);
+  // Untracked but not gitignored is the highest-risk moment: dotenvx just
+  // created the keys file and one `git add .` commits it
+  const [keysFileIgnored, setKeysFileIgnored] = useState(true);
+  const keysFilePath = keysFile?.path;
+  useEffect(() => {
+    if (!keysFilePath) {
+      setKeysFileTracked(false);
+      setKeysFileIgnored(true);
+      return;
+    }
+    invoke<boolean>("is_file_git_tracked", { filePath: keysFilePath })
+      .then(setKeysFileTracked)
+      .catch(() => setKeysFileTracked(false));
+    invoke<boolean>("is_file_git_ignored", { filePath: keysFilePath })
+      .then(setKeysFileIgnored)
+      .catch(() => setKeysFileIgnored(true));
+  }, [keysFilePath]);
+
+  const keysFileAtRisk = !keysFileTracked && !keysFileIgnored;
 
   // Watch for file changes - only watch the selected file
   const selectedEnvFile = project?.envFiles.find(
@@ -149,6 +179,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     // so "Show All" reveals plaintext without touching the files on disk
     const newDecrypted = new Map<string, string>();
     for (const file of project?.envFiles || []) {
+      if (file.type === "keys") continue;
       if (!file.variables.some((v) => v.isEncrypted)) continue;
       try {
         const json = await invoke<string>("get_decrypted_values", {
@@ -166,6 +197,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
 
     const allKeys = new Set<string>();
     project?.envFiles.forEach((file) => {
+      if (file.type === "keys") return;
       file.variables.forEach((variable) => {
         if (isDotenvxMetadata(variable.key)) return;
         allKeys.add(`${file.id}-${variable.key}`);
@@ -487,19 +519,38 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
             {project.path}
           </p>
         </div>
-        <Button
-          onClick={handleOpenFolder}
-          variant="outline"
-          size="sm"
-          className="gap-2"
-          title="Open folder in file explorer"
-        >
-          <FolderOpen className="h-4 w-4" />
-          Open Folder
-        </Button>
+        <div className="flex gap-2">
+          {keysFile && (
+            <Button
+              onClick={() => setShowKeysManager(true)}
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              title="View and rotate private decryption keys"
+            >
+              <Key className="h-4 w-4" />
+              Keys
+              {keysFileTracked ? (
+                <AlertTriangle className="h-4 w-4 text-destructive" />
+              ) : keysFileAtRisk ? (
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+              ) : null}
+            </Button>
+          )}
+          <Button
+            onClick={handleOpenFolder}
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            title="Open folder in file explorer"
+          >
+            <FolderOpen className="h-4 w-4" />
+            Open Folder
+          </Button>
+        </div>
       </div>
 
-      {project.envFiles.length === 0 ? (
+      {tabFiles.length === 0 ? (
         <Card>
           <CardContent className="pt-6">
             <div className="text-center text-muted-foreground">
@@ -515,15 +566,15 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
         </Card>
       ) : (
         <Tabs
-          defaultValue={project.envFiles[0]?.id}
-          value={selectedFileId || project.envFiles[0]?.id}
+          defaultValue={tabFiles[0]?.id}
+          value={selectedFileId || tabFiles[0]?.id}
           onValueChange={setSelectedFileId}
           className="w-full flex flex-col"
         >
           <div className="sticky top-4 z-10">
             <Card className="border-b p-0 py-1 px-1">
               <TabsList className="flex flex-1 flex-wrap gap-1 justify-start bg-transparent p-0 h-auto">
-                {project.envFiles.map((envFile) => (
+                {tabFiles.map((envFile) => (
                   <TabsTrigger
                     key={envFile.id}
                     value={envFile.id}
@@ -541,7 +592,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
             </Card>
           </div>
           <div className="pt-4">
-            {project.envFiles.map((envFile) => {
+            {tabFiles.map((envFile) => {
               const regularVariables = envFile.variables.filter(
                 (v) => !isDotenvxMetadata(v.key),
               );
@@ -591,14 +642,6 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                             className="gap-1 text-blue-600"
                           >
                             <Info className="h-3 w-3" /> Example
-                          </Badge>
-                        )}
-                        {envFile.type === "keys" && (
-                          <Badge
-                            variant="outline"
-                            className="gap-1 text-purple-600"
-                          >
-                            <Key className="h-3 w-3" /> Keys
                           </Badge>
                         )}
                       </div>
@@ -716,24 +759,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
 
                   <CardContent className="mt-5">
                     <div className="space-y-3">
-                      {envFile.type === "keys" ? (
-                        <>
-                          <div className="flex items-center gap-2">
-                            <Key className="h-4 w-4 text-muted-foreground" />
-                            <h4 className="font-medium">Key Rotation</h4>
-                          </div>
-                          <KeyRotationDisplay
-                            keysFile={envFile}
-                            onRotationComplete={() => {
-                              // Reload the project to get updated keys
-                              if (project) {
-                                onProjectUpdate(project);
-                              }
-                            }}
-                          />
-                        </>
-                      ) : (
-                        <>
+                      <>
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2">
                               <Key className="h-4 w-4 text-muted-foreground" />
@@ -915,7 +941,6 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                             </Button>
                           )}
                         </>
-                      )}
                     </div>
                   </CardContent>
                 </Card>
@@ -947,6 +972,55 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
           )}
         </DialogContent>
       </Dialog>
+
+      {/* Keys Dialog */}
+      {keysFile && (
+        <Dialog open={showKeysManager} onOpenChange={setShowKeysManager}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Private Keys - {keysFile.name}</DialogTitle>
+              <DialogClose onClick={() => setShowKeysManager(false)} />
+            </DialogHeader>
+            {keysFileTracked && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  <strong>{keysFile.name} is tracked by git!</strong> This
+                  file contains private decryption keys and must never be
+                  committed. Add it to .gitignore, then run{" "}
+                  <code>git rm --cached {keysFile.name}</code> to untrack it.
+                </AlertDescription>
+              </Alert>
+            )}
+            {keysFileAtRisk && (
+              <Alert className="border-amber-500/50 text-amber-600 dark:text-amber-400 [&>svg]:text-current">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription className="text-amber-600/90 dark:text-amber-400/90">
+                  <strong>{keysFile.name} is not covered by .gitignore.</strong>{" "}
+                  It contains private decryption keys and is one{" "}
+                  <code>git add .</code> away from being committed. Add{" "}
+                  <code>{keysFile.name}</code> to .gitignore.
+                </AlertDescription>
+              </Alert>
+            )}
+            <KeyRotationDisplay
+              keysFile={keysFile}
+              onRotationComplete={async () => {
+                // Rotation re-encrypts the .env files - reload from disk
+                const { FileScanner } = await import("../utils/fileScanner");
+                const updatedEnvFiles = await FileScanner.scanProjectFolder(
+                  project.path,
+                );
+                onProjectUpdate({
+                  ...project,
+                  envFiles: updatedEnvFiles,
+                  lastModified: new Date().toISOString(),
+                });
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 };

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -41,6 +41,10 @@ interface EnvFileViewerProps {
   onProjectUpdate: (project: Project) => void;
 }
 
+// DOTENV_PUBLIC_KEY* is dotenvx encryption metadata, not an app variable -
+// it is shown as a metadata row on the file card, not in the variables list
+const isDotenvxMetadata = (key: string) => key.startsWith("DOTENV_PUBLIC_KEY");
+
 export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   project,
   onProjectUpdate,
@@ -152,6 +156,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
         });
         const values: Record<string, string> = JSON.parse(json);
         for (const [key, value] of Object.entries(values)) {
+          if (isDotenvxMetadata(key)) continue;
           newDecrypted.set(`${file.id}-${key}`, value);
         }
       } catch (error) {
@@ -162,6 +167,7 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     const allKeys = new Set<string>();
     project?.envFiles.forEach((file) => {
       file.variables.forEach((variable) => {
+        if (isDotenvxMetadata(variable.key)) return;
         allKeys.add(`${file.id}-${variable.key}`);
       });
     });
@@ -535,7 +541,14 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
             </Card>
           </div>
           <div className="pt-4">
-            {project.envFiles.map((envFile) => (
+            {project.envFiles.map((envFile) => {
+              const regularVariables = envFile.variables.filter(
+                (v) => !isDotenvxMetadata(v.key),
+              );
+              const publicKeyVar = envFile.variables.find((v) =>
+                isDotenvxMetadata(v.key),
+              );
+              return (
               <TabsContent key={envFile.id} value={envFile.id} className="mt-4">
                 <Card>
                   <CardHeader>
@@ -635,6 +648,35 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                           )}
                       </div>
                     </div>
+                    {publicKeyVar && (
+                      <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground font-mono">
+                        <Key className="h-3 w-3" />
+                        <span>{publicKeyVar.key}:</span>
+                        <span title={publicKeyVar.value}>
+                          {publicKeyVar.value.length > 16
+                            ? `${publicKeyVar.value.slice(0, 8)}…${publicKeyVar.value.slice(-6)}`
+                            : publicKeyVar.value}
+                        </span>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() =>
+                            copyToClipboard(
+                              publicKeyVar.value,
+                              `pk-${envFile.id}`,
+                            )
+                          }
+                          className="h-5 w-5 p-0"
+                          title="Copy public key"
+                        >
+                          {copiedKey === `pk-${envFile.id}` ? (
+                            <Check className="h-3.5 w-3.5 text-green-600" />
+                          ) : (
+                            <Copy className="h-3.5 w-3.5" />
+                          )}
+                        </Button>
+                      </div>
+                    )}
                   </CardHeader>
 
                   {/* Validation Alerts */}
@@ -696,11 +738,11 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                             <div className="flex items-center gap-2">
                               <Key className="h-4 w-4 text-muted-foreground" />
                               <h4 className="font-medium">
-                                Variables ({envFile.variables.length})
+                                Variables ({regularVariables.length})
                               </h4>
                             </div>
-                            {envFile.variables.length > 0 &&
-                              envFile.variables.some((v) => v.value) && (
+                            {regularVariables.length > 0 &&
+                              regularVariables.some((v) => v.value) && (
                                 <Button
                                   variant="outline"
                                   size="sm"
@@ -726,13 +768,13 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                 </Button>
                               )}
                           </div>
-                          {envFile.variables.length === 0 ? (
+                          {regularVariables.length === 0 ? (
                             <p className="text-sm text-muted-foreground italic">
                               No variables found in this file.
                             </p>
                           ) : (
                             <div className="space-y-2">
-                              {envFile.variables.map((variable, index) => {
+                              {regularVariables.map((variable, index) => {
                                 const variableId = `${envFile.id}-${variable.key}`;
                                 const isVisible =
                                   visibleVariables.has(variableId);
@@ -837,23 +879,17 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                           )}
                                         </Button>
                                       )}
-                                      {variable.key !==
-                                        "DOTENV_PUBLIC_KEY" && (
-                                        <Button
-                                          variant="ghost"
-                                          size="sm"
-                                          onClick={() =>
-                                            startEditVariable(
-                                              envFile,
-                                              variable,
-                                            )
-                                          }
-                                          className="h-6 w-6 p-0"
-                                          title="Edit value (re-encrypted on save)"
-                                        >
-                                          <Pencil className="h-4 w-4" />
-                                        </Button>
-                                      )}
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() =>
+                                          startEditVariable(envFile, variable)
+                                        }
+                                        className="h-6 w-6 p-0"
+                                        title="Edit value (re-encrypted on save)"
+                                      >
+                                        <Pencil className="h-4 w-4" />
+                                      </Button>
                                     </div>
                                   </div>
                                 );
@@ -884,7 +920,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                   </CardContent>
                 </Card>
               </TabsContent>
-            ))}
+              );
+            })}
           </div>
         </Tabs>
       )}

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -24,6 +24,7 @@ import {
   Pencil,
   ArrowDownAZ,
   List,
+  Loader2,
 } from "lucide-react";
 import { VariableValueDisplay } from "./VariableValueDisplay";
 import { VariableForm } from "./VariableForm";
@@ -113,6 +114,9 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     null,
   );
   const [editInitialValue, setEditInitialValue] = useState("");
+  // Pencil click shells out to dotenvx to prefill the plaintext - show a
+  // spinner on the clicked pencil while that runs
+  const [editLoadingId, setEditLoadingId] = useState<string | null>(null);
   const [showBackupManager, setShowBackupManager] = useState(false);
   const [showKeysManager, setShowKeysManager] = useState(false);
   const [currentEnvFile, setCurrentEnvFile] = useState<EnvFile | null>(null);
@@ -418,21 +422,26 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
       const variableId = `${envFile.id}-${variable.key}`;
       let current = decryptedValues.get(variableId) ?? variable.value;
 
-      // Prefill the form with the plaintext, decrypting in memory if needed
-      if (variable.isEncrypted && !decryptedValues.has(variableId)) {
-        try {
-          current = await invoke<string>("get_decrypted_value", {
-            filePath: envFile.path,
-            key: variable.key,
-          });
-        } catch (error) {
-          console.error("Failed to decrypt variable for editing:", error);
-          current = "";
+      setEditLoadingId(variableId);
+      try {
+        // Prefill the form with the plaintext, decrypting in memory if needed
+        if (variable.isEncrypted && !decryptedValues.has(variableId)) {
+          try {
+            current = await invoke<string>("get_decrypted_value", {
+              filePath: envFile.path,
+              key: variable.key,
+            });
+          } catch (error) {
+            console.error("Failed to decrypt variable for editing:", error);
+            current = "";
+          }
         }
-      }
 
-      setEditInitialValue(current);
-      setEditingVariableId(variableId);
+        setEditInitialValue(current);
+        setEditingVariableId(variableId);
+      } finally {
+        setEditLoadingId(null);
+      }
     },
     [decryptedValues],
   );
@@ -1032,10 +1041,15 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                         onClick={() =>
                                           startEditVariable(envFile, variable)
                                         }
+                                        disabled={editLoadingId !== null}
                                         className="h-6 w-6 p-0"
-                                        title="Edit value (re-encrypted on save)"
+                                        title="Edit value"
                                       >
-                                        <Pencil className="h-4 w-4" />
+                                        {editLoadingId === variableId ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <Pencil className="h-4 w-4" />
+                                        )}
                                       </Button>
                                     </div>
                                   </div>

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -20,8 +20,11 @@ import {
   Check,
   FolderOpen,
   HardDrive,
+  Plus,
+  Pencil,
 } from "lucide-react";
 import { VariableValueDisplay } from "./VariableValueDisplay";
+import { VariableForm } from "./VariableForm";
 import { KeyRotationDisplay } from "./KeyRotationDisplay";
 import { BackupManager } from "./BackupManager";
 import {
@@ -97,6 +100,11 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
   }, []);
   const [showAllValues, setShowAllValues] = useState(false);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const [addingToFileId, setAddingToFileId] = useState<string | null>(null);
+  const [editingVariableId, setEditingVariableId] = useState<string | null>(
+    null,
+  );
+  const [editInitialValue, setEditInitialValue] = useState("");
   const [showBackupManager, setShowBackupManager] = useState(false);
   const [currentEnvFile, setCurrentEnvFile] = useState<EnvFile | null>(null);
   const [selectedFileId, setSelectedFileId] = useState<string | null>(
@@ -244,6 +252,99 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
       scheduleRemask(variableId);
     },
     [visibleVariables, decryptedValues, cancelRemask, hideVariable, scheduleRemask],
+  );
+
+  const saveVariable = useCallback(
+    async (envFile: EnvFile, key: string, value: string): Promise<boolean> => {
+      if (!project) return false;
+
+      try {
+        // dotenvx set encrypts the value in-flight when the file has a
+        // public key, so plaintext never lands on disk for encrypted files
+        await invoke<string>("set_env_value", {
+          filePath: envFile.path,
+          key,
+          value,
+        });
+
+        // Reload the file from disk to get updated variables
+        const { FileScanner } = await import("../utils/fileScanner");
+        const updatedEnvFiles = await FileScanner.scanProjectFolder(
+          project.path,
+        );
+        onProjectUpdate({
+          ...project,
+          envFiles: updatedEnvFiles,
+          lastModified: new Date().toISOString(),
+        });
+        return true;
+      } catch (error) {
+        console.error("Failed to set variable:", error);
+        alert(`Failed to save ${key}: ${error}`);
+        return false;
+      }
+    },
+    [project, onProjectUpdate],
+  );
+
+  const handleAddVariable = useCallback(
+    async (envFile: EnvFile, key: string, value: string) => {
+      if (envFile.variables.some((v) => v.key === key)) {
+        const proceed = await confirm(
+          `${key} already exists in ${envFile.name}. Overwrite its value?`,
+          {
+            title: "Overwrite variable?",
+            kind: "warning",
+            okLabel: "Overwrite",
+            cancelLabel: "Cancel",
+          },
+        );
+        if (!proceed) return;
+      }
+
+      if (await saveVariable(envFile, key, value)) {
+        setAddingToFileId(null);
+      }
+    },
+    [saveVariable],
+  );
+
+  const startEditVariable = useCallback(
+    async (envFile: EnvFile, variable: EnvVariable) => {
+      const variableId = `${envFile.id}-${variable.key}`;
+      let current = decryptedValues.get(variableId) ?? variable.value;
+
+      // Prefill the form with the plaintext, decrypting in memory if needed
+      if (variable.isEncrypted && !decryptedValues.has(variableId)) {
+        try {
+          current = await invoke<string>("get_decrypted_value", {
+            filePath: envFile.path,
+            key: variable.key,
+          });
+        } catch (error) {
+          console.error("Failed to decrypt variable for editing:", error);
+          current = "";
+        }
+      }
+
+      setEditInitialValue(current);
+      setEditingVariableId(variableId);
+    },
+    [decryptedValues],
+  );
+
+  const handleEditVariable = useCallback(
+    async (envFile: EnvFile, variable: EnvVariable, value: string) => {
+      const variableId = `${envFile.id}-${variable.key}`;
+      if (await saveVariable(envFile, variable.key, value)) {
+        // Keep the in-memory plaintext cache in sync if this value was revealed
+        setDecryptedValues((prev) =>
+          prev.has(variableId) ? new Map(prev).set(variableId, value) : prev,
+        );
+        setEditingVariableId(null);
+      }
+    },
+    [saveVariable],
   );
 
   const handleOpenFolder = useCallback(async () => {
@@ -635,6 +736,26 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                 const variableId = `${envFile.id}-${variable.key}`;
                                 const isVisible =
                                   visibleVariables.has(variableId);
+                                if (editingVariableId === variableId) {
+                                  return (
+                                    <VariableForm
+                                      key={index}
+                                      initialKey={variable.key}
+                                      keyLocked
+                                      initialValue={editInitialValue}
+                                      onSave={(_key, value) =>
+                                        handleEditVariable(
+                                          envFile,
+                                          variable,
+                                          value,
+                                        )
+                                      }
+                                      onCancel={() =>
+                                        setEditingVariableId(null)
+                                      }
+                                    />
+                                  );
+                                }
                                 return (
                                   <div
                                     key={index}
@@ -716,11 +837,46 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                           )}
                                         </Button>
                                       )}
+                                      {variable.key !==
+                                        "DOTENV_PUBLIC_KEY" && (
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          onClick={() =>
+                                            startEditVariable(
+                                              envFile,
+                                              variable,
+                                            )
+                                          }
+                                          className="h-6 w-6 p-0"
+                                          title="Edit value (re-encrypted on save)"
+                                        >
+                                          <Pencil className="h-4 w-4" />
+                                        </Button>
+                                      )}
                                     </div>
                                   </div>
                                 );
                               })}
                             </div>
+                          )}
+                          {addingToFileId === envFile.id ? (
+                            <VariableForm
+                              onSave={(key, value) =>
+                                handleAddVariable(envFile, key, value)
+                              }
+                              onCancel={() => setAddingToFileId(null)}
+                            />
+                          ) : (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setAddingToFileId(envFile.id)}
+                              className="gap-1 text-muted-foreground"
+                            >
+                              <Plus className="h-4 w-4" />
+                              Add Variable
+                            </Button>
                           )}
                         </>
                       )}

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -22,6 +22,8 @@ import {
   HardDrive,
   Plus,
   Pencil,
+  ArrowDownAZ,
+  List,
 } from "lucide-react";
 import { VariableValueDisplay } from "./VariableValueDisplay";
 import { VariableForm } from "./VariableForm";
@@ -103,6 +105,8 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
     return () => timers.forEach(clearTimeout);
   }, []);
   const [showAllValues, setShowAllValues] = useState(false);
+  // Display-only sort - the file on disk keeps its original line order
+  const [sortAlphabetically, setSortAlphabetically] = useState(false);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [addingToFileId, setAddingToFileId] = useState<string | null>(null);
   const [editingVariableId, setEditingVariableId] = useState<string | null>(
@@ -594,6 +598,11 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
               const regularVariables = envFile.variables.filter(
                 (v) => !isDotenvxMetadata(v.key),
               );
+              const displayVariables = sortAlphabetically
+                ? [...regularVariables].sort((a, b) =>
+                    a.key.localeCompare(b.key),
+                  )
+                : regularVariables;
               const publicKeyVar = envFile.variables.find((v) =>
                 isDotenvxMetadata(v.key),
               );
@@ -765,6 +774,36 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                 Variables ({regularVariables.length})
                               </h4>
                             </div>
+                            <div className="flex items-center gap-2">
+                            {regularVariables.length > 1 && (
+                              <Button
+                                variant={
+                                  sortAlphabetically ? "secondary" : "outline"
+                                }
+                                size="sm"
+                                onClick={() =>
+                                  setSortAlphabetically(!sortAlphabetically)
+                                }
+                                className="h-8"
+                                title={
+                                  sortAlphabetically
+                                    ? "Show variables in file order"
+                                    : "Sort A-Z (display only, file unchanged)"
+                                }
+                              >
+                                {sortAlphabetically ? (
+                                  <>
+                                    <List className="h-4 w-4 mr-1" />
+                                    Unsort
+                                  </>
+                                ) : (
+                                  <>
+                                    <ArrowDownAZ className="h-4 w-4 mr-1" />
+                                    Sort A-Z
+                                  </>
+                                )}
+                              </Button>
+                            )}
                             {regularVariables.length > 0 &&
                               regularVariables.some((v) => v.value) && (
                                 <Button
@@ -791,9 +830,10 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
                                   )}
                                 </Button>
                               )}
+                            </div>
                           </div>
                           <div className="space-y-2">
-                              {regularVariables.map((variable, index) => {
+                              {displayVariables.map((variable, index) => {
                                 const variableId = `${envFile.id}-${variable.key}`;
                                 const isVisible =
                                   visibleVariables.has(variableId);

--- a/src/components/EnvFileViewer.tsx
+++ b/src/components/EnvFileViewer.tsx
@@ -35,6 +35,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogClose,
 } from "./ui/dialog";
 import { useFileWatcher } from "../hooks/useFileWatcher";
@@ -1140,7 +1141,12 @@ export const EnvFileViewer: React.FC<EnvFileViewerProps> = ({
         <Dialog open={showKeysManager} onOpenChange={setShowKeysManager}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Private Keys - {keysFile.name}</DialogTitle>
+              <div className="space-y-1">
+                <DialogTitle>Private Keys</DialogTitle>
+                <DialogDescription className="font-mono text-xs break-all">
+                  {keysFile.path}
+                </DialogDescription>
+              </div>
               <DialogClose onClick={() => setShowKeysManager(false)} />
             </DialogHeader>
             {keysFileTracked && (

--- a/src/components/KeyRotationDisplay.tsx
+++ b/src/components/KeyRotationDisplay.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { EnvFile, EnvVariable } from "../types";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
-import { RotateCw, Copy, Check } from "lucide-react";
+import { RotateCw, Copy, Check, Eye, EyeOff } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 
 interface KeyRotationDisplayProps {
@@ -10,12 +10,52 @@ interface KeyRotationDisplayProps {
   onRotationComplete: () => void;
 }
 
+// Match EnvFileViewer's re-mask delay so revealed secrets never linger
+const REMASK_DELAY_MS = 60_000;
+
 export const KeyRotationDisplay: React.FC<KeyRotationDisplayProps> = ({
   keysFile,
   onRotationComplete,
 }) => {
   const [isRotating, setIsRotating] = useState<string | null>(null);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
+  const remaskTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  useEffect(() => {
+    const timers = remaskTimers.current;
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  const toggleKeyVisibility = (key: string) => {
+    const timer = remaskTimers.current.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      remaskTimers.current.delete(key);
+    }
+    setVisibleKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+        remaskTimers.current.set(
+          key,
+          setTimeout(() => {
+            remaskTimers.current.delete(key);
+            setVisibleKeys((p) => {
+              const n = new Set(p);
+              n.delete(key);
+              return n;
+            });
+          }, REMASK_DELAY_MS),
+        );
+      }
+      return next;
+    });
+  };
 
   const handleRotateKey = async (variable: EnvVariable) => {
     setIsRotating(variable.key);
@@ -47,45 +87,73 @@ export const KeyRotationDisplay: React.FC<KeyRotationDisplayProps> = ({
           const isPrivateKey = variable.key.includes("DOTENV_PRIVATE_KEY");
           if (!isPrivateKey) return null;
 
+          const isVisible = visibleKeys.has(variable.key);
+
           return (
             <div
               key={index}
-              className="flex items-center justify-between p-3 bg-muted/30 rounded-md"
+              className="flex items-center justify-between gap-3 p-3 bg-muted/30 rounded-md"
             >
-              <div className="flex items-center gap-2 flex-1">
-                <span className="font-mono text-sm font-medium">
-                  {variable.key}
-                </span>
-                <Badge
-                  variant={variable.value ? "default" : "secondary"}
-                  className="text-xs"
-                >
-                  {variable.value ? "Present" : "Missing"}
-                </Badge>
-                {!variable.value && (
-                  <span className="text-xs text-muted-foreground italic">
-                    (No key present - will be created on rotation)
+              <div className="flex-1 min-w-0 space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-sm font-medium">
+                    {variable.key}
                   </span>
+                  {!variable.value && (
+                    <>
+                      <Badge variant="secondary" className="text-xs">
+                        Missing
+                      </Badge>
+                      <span className="text-xs text-muted-foreground italic">
+                        (No key present - will be created on rotation)
+                      </span>
+                    </>
+                  )}
+                </div>
+                {variable.value && (
+                  <div className="font-mono text-xs text-muted-foreground break-all">
+                    {/* Fixed-width mask so the dots don't leak key length */}
+                    {isVisible ? variable.value : "•".repeat(24)}
+                  </div>
                 )}
               </div>
 
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 shrink-0">
                 {variable.value && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      copyToClipboard(variable.value, variable.key)
-                    }
-                    className="h-6 w-6 p-0"
-                    title="Copy key"
-                  >
-                    {copiedKey === variable.key ? (
-                      <Check className="h-4 w-4 text-green-600" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => toggleKeyVisibility(variable.key)}
+                      className="h-6 w-6 p-0"
+                      title={
+                        isVisible
+                          ? "Hide key"
+                          : "Reveal key (re-masks after 60s)"
+                      }
+                    >
+                      {isVisible ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        copyToClipboard(variable.value, variable.key)
+                      }
+                      className="h-6 w-6 p-0"
+                      title="Copy key"
+                    >
+                      {copiedKey === variable.key ? (
+                        <Check className="h-4 w-4 text-green-600" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </>
                 )}
 
                 <Button

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -5,8 +5,7 @@ import { StorageManager } from "../storage";
 import { FileScanner } from "../utils/fileScanner";
 import { Button } from "./ui/button";
 import { Card, CardContent } from "./ui/card";
-import { Badge } from "./ui/badge";
-import { RefreshCw, Trash2, Plus } from "lucide-react";
+import { RefreshCw, Trash2, Plus, FileText } from "lucide-react";
 
 interface ProjectSelectorProps {
   projects: Project[];
@@ -155,11 +154,10 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
                     <p className="text-xs text-muted-foreground font-mono mt-1 truncate">
                       {project.path}
                     </p>
-                    <div className="flex items-center gap-2 mt-2">
-                      <Badge variant="secondary" className="text-xs">
-                        {project.envFiles.length} env file
-                        {project.envFiles.length !== 1 ? "s" : ""}
-                      </Badge>
+                    <div className="flex items-center gap-1 mt-1.5 text-xs text-muted-foreground">
+                      <FileText className="h-3 w-3" />
+                      {project.envFiles.length} env file
+                      {project.envFiles.length !== 1 ? "s" : ""}
                     </div>
                   </div>
                   <div className="flex gap-1 flex-shrink-0">

--- a/src/components/VariableForm.tsx
+++ b/src/components/VariableForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "./ui/button";
 import { Check, X } from "lucide-react";
 
@@ -22,6 +22,18 @@ export const VariableForm: React.FC<VariableFormProps> = ({
   const [key, setKey] = useState(initialKey);
   const [value, setValue] = useState(initialValue);
   const [isSaving, setIsSaving] = useState(false);
+  const valueInputRef = useRef<HTMLInputElement>(null);
+
+  // When editing, focus the value with the caret at the start so long
+  // values read from the beginning instead of scrolled to the end
+  useEffect(() => {
+    if (keyLocked && valueInputRef.current) {
+      const el = valueInputRef.current;
+      el.focus();
+      el.setSelectionRange(0, 0);
+      el.scrollLeft = 0;
+    }
+  }, [keyLocked]);
 
   const trimmedKey = key.trim();
   const keyValid = KEY_PATTERN.test(trimmedKey);
@@ -45,7 +57,9 @@ export const VariableForm: React.FC<VariableFormProps> = ({
   };
 
   return (
-    <div className="flex items-center justify-between gap-2 p-3 bg-muted/30 rounded-md border border-dashed">
+    <div className="flex items-center justify-between gap-2 p-3 bg-muted/30 rounded-md ring-1 ring-inset ring-border">
+      {/* Underline-style zero-padding inputs and three fixed button slots
+          mirror the display row's geometry so nothing shifts while editing */}
       <input
         type="text"
         placeholder="KEY"
@@ -57,7 +71,7 @@ export const VariableForm: React.FC<VariableFormProps> = ({
         spellCheck={false}
         autoCorrect="off"
         autoCapitalize="off"
-        className="font-mono text-sm font-medium bg-transparent border rounded px-2 py-1 w-48 disabled:border-transparent disabled:px-0"
+        className="font-mono text-sm font-medium bg-transparent border-0 border-b border-input p-0 w-48 outline-none focus:border-ring disabled:border-transparent"
       />
       <div className="flex items-center gap-2">
         <input
@@ -66,11 +80,11 @@ export const VariableForm: React.FC<VariableFormProps> = ({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
-          autoFocus={keyLocked}
+          ref={valueInputRef}
           spellCheck={false}
           autoCorrect="off"
           autoCapitalize="off"
-          className="font-mono text-sm text-muted-foreground bg-transparent border rounded px-2 py-1"
+          className="font-mono text-sm text-muted-foreground bg-transparent border-0 border-b border-input p-0 outline-none focus:border-ring"
           style={{ width: "300px" }}
         />
         <Button
@@ -93,6 +107,7 @@ export const VariableForm: React.FC<VariableFormProps> = ({
         >
           <X className="h-4 w-4" />
         </Button>
+        <span className="h-6 w-6" />
       </div>
     </div>
   );

--- a/src/components/VariableForm.tsx
+++ b/src/components/VariableForm.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Button } from "./ui/button";
-import { Check, X } from "lucide-react";
+import { Check, X, Lock, LockOpen } from "lucide-react";
 
 interface VariableFormProps {
   initialKey?: string;
   keyLocked?: boolean;
   initialValue?: string;
-  onSave: (key: string, value: string) => Promise<void>;
+  // When set, show a lock toggle so the user chooses encrypted vs plaintext
+  // before saving - the file's current setup provides the default
+  encryptToggle?: { initial: boolean };
+  onSave: (key: string, value: string, encrypt?: boolean) => Promise<void>;
   onCancel: () => void;
 }
 
@@ -16,11 +19,13 @@ export const VariableForm: React.FC<VariableFormProps> = ({
   initialKey = "",
   keyLocked = false,
   initialValue = "",
+  encryptToggle,
   onSave,
   onCancel,
 }) => {
   const [key, setKey] = useState(initialKey);
   const [value, setValue] = useState(initialValue);
+  const [encrypt, setEncrypt] = useState(encryptToggle?.initial ?? false);
   const [isSaving, setIsSaving] = useState(false);
   const valueInputRef = useRef<HTMLInputElement>(null);
 
@@ -42,7 +47,7 @@ export const VariableForm: React.FC<VariableFormProps> = ({
     if (!keyValid || isSaving) return;
     setIsSaving(true);
     try {
-      await onSave(trimmedKey, value);
+      await onSave(trimmedKey, value, encrypt);
     } finally {
       setIsSaving(false);
     }
@@ -87,6 +92,28 @@ export const VariableForm: React.FC<VariableFormProps> = ({
           className="font-mono text-sm text-muted-foreground bg-transparent border-0 border-b border-input p-0 outline-none focus:border-ring"
           style={{ width: "300px" }}
         />
+        {encryptToggle ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setEncrypt((prev) => !prev)}
+            disabled={isSaving}
+            className="h-6 w-6 p-0"
+            title={
+              encrypt
+                ? "Will encrypt on save - click to keep plaintext"
+                : "Will save as plaintext - click to encrypt"
+            }
+          >
+            {encrypt ? (
+              <Lock className="h-4 w-4" />
+            ) : (
+              <LockOpen className="h-4 w-4 text-muted-foreground" />
+            )}
+          </Button>
+        ) : (
+          <span className="h-6 w-6" />
+        )}
         <Button
           variant="ghost"
           size="sm"
@@ -107,7 +134,6 @@ export const VariableForm: React.FC<VariableFormProps> = ({
         >
           <X className="h-4 w-4" />
         </Button>
-        <span className="h-6 w-6" />
       </div>
     </div>
   );

--- a/src/components/VariableForm.tsx
+++ b/src/components/VariableForm.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+import { Check, X } from "lucide-react";
+
+interface VariableFormProps {
+  initialKey?: string;
+  keyLocked?: boolean;
+  initialValue?: string;
+  onSave: (key: string, value: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+const KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export const VariableForm: React.FC<VariableFormProps> = ({
+  initialKey = "",
+  keyLocked = false,
+  initialValue = "",
+  onSave,
+  onCancel,
+}) => {
+  const [key, setKey] = useState(initialKey);
+  const [value, setValue] = useState(initialValue);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const trimmedKey = key.trim();
+  const keyValid = KEY_PATTERN.test(trimmedKey);
+
+  const handleSave = async () => {
+    if (!keyValid || isSaving) return;
+    setIsSaving(true);
+    try {
+      await onSave(trimmedKey, value);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSave();
+    } else if (e.key === "Escape") {
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-2 p-3 bg-muted/30 rounded-md border border-dashed">
+      <input
+        type="text"
+        placeholder="KEY"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={keyLocked}
+        autoFocus={!keyLocked}
+        spellCheck={false}
+        autoCorrect="off"
+        autoCapitalize="off"
+        className="font-mono text-sm font-medium bg-transparent border rounded px-2 py-1 w-48 disabled:border-transparent disabled:px-0"
+      />
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          placeholder="value"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          autoFocus={keyLocked}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          className="font-mono text-sm text-muted-foreground bg-transparent border rounded px-2 py-1"
+          style={{ width: "300px" }}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleSave}
+          disabled={!keyValid || isSaving}
+          className="h-6 w-6 p-0"
+          title={keyValid ? "Save" : "Key must look like MY_VARIABLE"}
+        >
+          <Check className="h-4 w-4 text-green-600" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="h-6 w-6 p-0"
+          title="Cancel"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/VariableValueDisplay.tsx
+++ b/src/components/VariableValueDisplay.tsx
@@ -27,10 +27,7 @@ export const VariableValueDisplay: React.FC<VariableValueDisplayProps> = ({
       autoCorrect="off"
       autoCapitalize="off"
       className="text-sm text-muted-foreground font-mono bg-transparent border-none outline-none p-0 cursor-text"
-      style={{
-        width: "300px",
-        textAlign: isVisible ? "left" : "right",
-      }}
+      style={{ width: "300px" }}
     />
   );
 };

--- a/src/components/VariableValueDisplay.tsx
+++ b/src/components/VariableValueDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 interface VariableValueDisplayProps {
   value: string;
@@ -9,53 +9,28 @@ export const VariableValueDisplay: React.FC<VariableValueDisplayProps> = ({
   value,
   isVisible,
 }) => {
-  const [isHovering, setIsHovering] = useState(false);
-
   const displayValue = isVisible
     ? value || "(empty)"
     : value
     ? "••••••••"
     : "(empty)";
-  const shouldScroll = isHovering && isVisible && value && value.length > 20;
 
   return (
-    <div
-      className="relative overflow-hidden"
-      style={{ width: "300px" }}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
-    >
-      <span
-        className={`text-sm text-muted-foreground font-mono block ${
-          shouldScroll ? "animate-scroll" : ""
-        }`}
-        style={
-          shouldScroll
-            ? {
-                animation: "scroll 8s linear infinite",
-                whiteSpace: "nowrap",
-              }
-            : {
-                whiteSpace: "nowrap",
-                textOverflow: "ellipsis",
-                overflow: "hidden",
-                textAlign: !isVisible ? "right" : "left",
-              }
-        }
-      >
-        {displayValue}
-      </span>
-
-      <style>{`
-        @keyframes scroll {
-          0% {
-            transform: translateX(0);
-          }
-          100% {
-            transform: translateX(-100%);
-          }
-        }
-      `}</style>
-    </div>
+    <input
+      type="text"
+      // Controlled with a fixed value instead of readOnly: WebKit suppresses
+      // the caret and cursor-key handling in readonly inputs, so this keeps
+      // normal textbox behavior while React discards any typed changes
+      value={displayValue}
+      onChange={() => {}}
+      spellCheck={false}
+      autoCorrect="off"
+      autoCapitalize="off"
+      className="text-sm text-muted-foreground font-mono bg-transparent border-none outline-none p-0 cursor-text"
+      style={{
+        width: "300px",
+        textAlign: isVisible ? "left" : "right",
+      }}
+    />
   );
 };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -51,7 +51,7 @@ export function DialogContent({
 
 export function DialogHeader({ children, className = "" }: DialogHeaderProps) {
   return (
-    <div className={`flex items-center justify-between mb-4 ${className}`}>
+    <div className={`flex items-start justify-between mb-4 ${className}`}>
       {children}
     </div>
   );
@@ -59,6 +59,15 @@ export function DialogHeader({ children, className = "" }: DialogHeaderProps) {
 
 export function DialogTitle({ children, className = "" }: DialogTitleProps) {
   return <h2 className={`text-xl font-bold ${className}`}>{children}</h2>;
+}
+
+export function DialogDescription({
+  children,
+  className = "",
+}: DialogTitleProps) {
+  return (
+    <p className={`text-sm text-muted-foreground ${className}`}>{children}</p>
+  );
 }
 
 export function DialogClose({ onClick }: DialogCloseProps) {

--- a/src/hooks/useFileWatcher.ts
+++ b/src/hooks/useFileWatcher.ts
@@ -5,53 +5,72 @@ import { EnvFile } from "../types";
 
 interface FileWatcherOptions {
   projectPath: string;
-  selectedFilePath?: string;
+  // Files to poll for changes - typically the selected tab and .env.keys
+  watchPaths?: (string | undefined)[];
   onFilesChanged: (envFiles: EnvFile[]) => void;
   pollInterval?: number;
 }
 
+// NUL never appears in file paths, unlike spaces
+const PATH_SEPARATOR = "\u0000";
+
 export const useFileWatcher = ({
   projectPath,
-  selectedFilePath,
+  watchPaths,
   onFilesChanged,
   pollInterval = 5000,
 }: FileWatcherOptions) => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const lastModifiedRef = useRef<number | null>(null);
+  const hashesRef = useRef<Map<string, number>>(new Map());
   const lastScannedRef = useRef<number>(0);
 
+  // Join to a string so an inline array prop doesn't reset the interval
+  // on every render
+  const pathsKey = (watchPaths ?? []).filter(Boolean).join(PATH_SEPARATOR);
+
   const checkForChanges = useCallback(async () => {
-    if (!projectPath || !selectedFilePath) {
+    const paths = pathsKey ? pathsKey.split(PATH_SEPARATOR) : [];
+    if (!projectPath || paths.length === 0) {
       return;
     }
 
-    try {
-      // Only read the selected file to check for changes
-      const content = await invoke<string>("read_text_file", {
-        path: selectedFilePath,
-      });
-
-      // Use content hash as a simple change detector
-      const contentHash = content.length;
-      const previousHash = lastModifiedRef.current;
-
-      if (previousHash !== contentHash) {
-        lastModifiedRef.current = contentHash;
-
-        // Only rescan the project if the selected file changed
-        // This reduces the number of full scans
-        const now = Date.now();
-        if (now - lastScannedRef.current > 10000) {
-          // Rescan every 10 seconds max
-          const envFiles = await FileScanner.scanProjectFolder(projectPath);
-          onFilesChanged(envFiles);
-          lastScannedRef.current = now;
-        }
+    const newHashes = new Map<string, number>();
+    let changed = false;
+    for (const path of paths) {
+      let contentHash: number;
+      try {
+        // Use content length as a simple change detector
+        const content = await invoke<string>("read_text_file", { path });
+        contentHash = content.length;
+      } catch {
+        // Unreadable (e.g. deleted) counts as a distinct state, so a
+        // deleted .env.keys still triggers a rescan once
+        contentHash = -1;
       }
-    } catch (error) {
-      console.error("Error checking for file changes:", error);
+      newHashes.set(path, contentHash);
+      if (hashesRef.current.get(path) !== contentHash) {
+        changed = true;
+      }
     }
-  }, [projectPath, selectedFilePath, onFilesChanged]);
+
+    if (!changed) {
+      return;
+    }
+
+    // Rescan every 10 seconds max; leave hashes uncommitted when
+    // throttled so the change is retried on the next poll
+    const now = Date.now();
+    if (now - lastScannedRef.current > 10000) {
+      try {
+        hashesRef.current = newHashes;
+        const envFiles = await FileScanner.scanProjectFolder(projectPath);
+        onFilesChanged(envFiles);
+        lastScannedRef.current = now;
+      } catch (error) {
+        console.error("Error checking for file changes:", error);
+      }
+    }
+  }, [projectPath, pathsKey, onFilesChanged]);
 
   useEffect(() => {
     // Initial check

--- a/src/utils/fileScanner.ts
+++ b/src/utils/fileScanner.ts
@@ -106,14 +106,25 @@ export class FileScanner {
     envFiles: EnvFile[],
     exampleFile: EnvFile,
   ): EnvFile[] {
-    const exampleKeys = new Set(exampleFile.variables.map((v) => v.key));
+    // DOTENV_PUBLIC_KEY* is dotenvx metadata, not an app variable - ignore it
+    const isDotenvxMetadata = (key: string) =>
+      key.startsWith("DOTENV_PUBLIC_KEY");
+    const exampleKeys = new Set(
+      exampleFile.variables
+        .filter((v) => !isDotenvxMetadata(v.key))
+        .map((v) => v.key),
+    );
 
     return envFiles.map((file) => {
       if (file.type === "example" || file.type === "keys") {
         return file; // Skip validation for example and keys files
       }
 
-      const fileKeys = new Set(file.variables.map((v) => v.key));
+      const fileKeys = new Set(
+        file.variables
+          .filter((v) => !isDotenvxMetadata(v.key))
+          .map((v) => v.key),
+      );
       const missingKeys = Array.from(exampleKeys).filter(
         (key) => !fileKeys.has(key),
       );

--- a/src/utils/fileScanner.ts
+++ b/src/utils/fileScanner.ts
@@ -38,6 +38,8 @@ export class FileScanner {
         }
       }
 
+      envFiles.sort((a, b) => a.name.localeCompare(b.name));
+
       // Validate keys against .env.example if it exists
       const exampleFile = envFiles.find((file) => file.name === ".env.example");
       if (exampleFile) {


### PR DESCRIPTION
Makes it possible to view, copy, and edit secrets without ever writing plaintext to disk, plus safety guards and UI cleanup.

## In-memory viewing (files on disk never change)
- Eye icon decrypts one variable via `dotenvx get KEY -f <file>` and shows it from memory
- Show All decrypts whole files via `dotenvx get -f <file> --format json`
- Copy button copies the decrypted value without displaying it; clipboard auto-clears after 30s
- Every control that shells out to decrypt (eye, pencil, copy, Show All) shows a spinner while dotenvx runs
- Revealed values auto re-mask after 60s; plaintext lives in memory only while visible
- Only encrypted values are masked - plaintext values (already readable on disk) display as-is

## Editing
- Inline "Add Variable" form per file, saved via `dotenvx set` (new values encrypted before writing)
- Add form has a lock toggle choosing encrypted vs plaintext; defaults follow the file (keypair present -> encrypt, keyless -> plaintext) so adding to a plaintext file no longer silently encrypts it
- Pencil icon edits an existing value in place (key locked, plaintext prefilled in memory)
- Edits preserve the variable's plaintext/encrypted state; example files always stay plaintext
- Lock icon on a plaintext value encrypts just that value via `dotenvx encrypt -k KEY`
- Overwriting an existing key asks for confirmation

## Safety
- Full-file Decrypt warns when the file is git-tracked (committable plaintext)
- Encrypting into a keyless file (via lock icon or add form) confirms before bootstrapping `DOTENV_PUBLIC_KEY`/`.env.keys`
- `.env.keys` warnings: red alert if git-tracked, amber if not covered by .gitignore

## Keys dialog
- Private keys display masked with an eye toggle (60s auto re-mask) instead of a "Present" badge
- Title is "Private Keys" with the full `.env.keys` path as a subtitle
- Per-key Rotate and Copy buttons

## Freshness
- Sidebar refresh now updates the selected project too (stale copy kept showing deleted keys)
- File watcher polls `.env.keys` alongside the selected tab, so external edits to keys show up without a manual refresh; a deleted keys file also triggers a rescan

## UI
- `.env.keys` leaves the tab strip; a Keys button in the header opens the rotation dialog
- `DOTENV_PUBLIC_KEY` shows as file metadata with a copy button instead of a variable
- Tabs restyled as bordered chips with lock/document icons; clear active state
- Values are selectable, consistently aligned text fields; the edit form matches the row geometry so nothing shifts
- Display-only A-Z sort for variables; files sort alphabetically; Unencrypted badge is amber
- Sidebar project cards show the env-file count as plain muted text instead of a badge

## Testing
- `npm run build` and `cargo check` pass; `dotenvx get`/`set`/`encrypt -k` behavior verified end-to-end against temp encrypted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)